### PR TITLE
Fix tar command for compatibility with FreeBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+get-wget-lua.tmp/

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Ensure that you have the Arch equivalent of bzip2 installed as well.
 
 ### For FreeBSD:
 
-Honestly, I have no idea. `./get-wget-lua.sh` supposedly doesn't work due to differences in the `tar` that ships with FreeBSD. Another problem is the apparent absence of Lua 5.1 development headers. If you figure this out, please do let us know on IRC (irc.efnet.org #archiveteam).
+Honestly, I have no idea. A problem is the apparent absence of Lua 5.1 development headers. If you figure this out, please do let us know on IRC (irc.efnet.org #archiveteam).
 
 Troubleshooting
 =========================

--- a/get-wget-lua.sh
+++ b/get-wget-lua.sh
@@ -27,10 +27,10 @@ cd get-wget-lua.tmp
 
 if builtin type -p curl &>/dev/null
 then
-  curl -L $WGET_DOWNLOAD_URL | tar -xj --strip-components=1
+  curl -L $WGET_DOWNLOAD_URL | tar -xjf - --strip-components=1
 elif builtin type -p wget &>/dev/null
 then
-  wget --output-document=- $WGET_DOWNLOAD_URL | tar -xj --strip-components=1
+  wget --output-document=- $WGET_DOWNLOAD_URL | tar -xjf - --strip-components=1
 else
   echo "You need Curl or Wget to download the source files."
   exit 1


### PR DESCRIPTION
You just have to explicitly specify `-` as the input file. By default it tries to read from `/dev/sa0`, because it's a **t**ape **ar**chiver :D

About the Lua headers — the configure script in `get-wget-lua` has a hardcoded `-I/usr/include/lua5.1` path instead of using `pkg-config`. The path on FreeBSD is `/usr/local/include/lua51` but really just use pkg-config.